### PR TITLE
add dont_get arg to get_ems_data

### DIFF
--- a/R/ems_sqlite.R
+++ b/R/ems_sqlite.R
@@ -134,30 +134,33 @@ save_historic_data <- function(csv_file, db_path, n) {
 #' @param from_date A date string in a standard unambiguous format (e.g., "YYYY/MM/DD")
 #' @param to_date A date string in a standard unambiguous format (e.g., "YYYY/MM/DD")
 #' @param cols colums. Default "wq". See \code{link{get_ems_data}} for further documentation.
+#' @param check_exists should the function check for cached data or updates? Default \code{TRUE}.
 #'
 #' @return a data frame of the results
 #' @export
 #'
 #' @importFrom DBI dbConnect dbDisconnect dbGetQuery
 read_historic_data <- function(emsid = NULL, parameter = NULL, param_code = NULL,
-                               from_date = NULL, to_date = NULL, cols = "wq") {
+                               from_date = NULL, to_date = NULL, cols = "wq", check_exists = TRUE) {
 
   file_meta <- get_file_metadata("historic")
   cache_date <- get_cache_date("historic")
   db_path <- write_db_path()
 
   ## Check for missing or outdated historic database
-  exit_fun <- FALSE
-  if (!file.exists(db_path)) {
-    exit_fun <- TRUE
-  } else if (cache_date < file_meta[["server_date"]] && file.exists(db_path)) {
-    ans <- readline(paste("Your version of the historic dataset is out of date.",
-                          "Would you like to continue with the version you have (y/n)? ",
-                          sep = "\n"))
-    if (tolower(ans) != "y") exit_fun <- TRUE
+  if(check_exists){
+    exit_fun <- FALSE
+    if (!file.exists(db_path)) {
+      exit_fun <- TRUE
+    } else if (cache_date < file_meta[["server_date"]] && file.exists(db_path)) {
+      ans <- readline(paste("Your version of the historic dataset is out of date.",
+                            "Would you like to continue with the version you have (y/n)? ",
+                            sep = "\n"))
+      if (tolower(ans) != "y") exit_fun <- TRUE
+    }
+    if (exit_fun) stop("Please download the historic data with\n",
+                       " the 'download_historic_data' function.")
   }
-  if (exit_fun) stop("Please download the historic data with\n",
-                 " the 'download_historic_data' function.")
 
   qry <- construct_historic_sql(emsid = emsid, parameter = parameter,
                                 param_code = param_code, from_date = from_date,

--- a/R/ems_sqlite.R
+++ b/R/ems_sqlite.R
@@ -134,33 +134,36 @@ save_historic_data <- function(csv_file, db_path, n) {
 #' @param from_date A date string in a standard unambiguous format (e.g., "YYYY/MM/DD")
 #' @param to_date A date string in a standard unambiguous format (e.g., "YYYY/MM/DD")
 #' @param cols colums. Default "wq". See \code{link{get_ems_data}} for further documentation.
-#' @param check_exists should the function check for cached data or updates? Default \code{TRUE}.
+#' @param check_db should the function check for cached data or updates? Default \code{TRUE}.
 #'
 #' @return a data frame of the results
 #' @export
 #'
 #' @importFrom DBI dbConnect dbDisconnect dbGetQuery
 read_historic_data <- function(emsid = NULL, parameter = NULL, param_code = NULL,
-                               from_date = NULL, to_date = NULL, cols = "wq", check_exists = TRUE) {
+                               from_date = NULL, to_date = NULL, cols = "wq", check_db = TRUE) {
 
-  file_meta <- get_file_metadata("historic")
-  cache_date <- get_cache_date("historic")
   db_path <- write_db_path()
+  exit_fun <- FALSE
+  if (!file.exists(db_path)) {
+    exit_fun <- TRUE
+  }
 
   ## Check for missing or outdated historic database
-  if(check_exists){
-    exit_fun <- FALSE
-    if (!file.exists(db_path)) {
-      exit_fun <- TRUE
-    } else if (cache_date < file_meta[["server_date"]] && file.exists(db_path)) {
+  if(check_db){
+    file_meta <- get_file_metadata("historic")
+    cache_date <- get_cache_date("historic")
+     if (cache_date < file_meta[["server_date"]] && file.exists(db_path)) {
       ans <- readline(paste("Your version of the historic dataset is out of date.",
                             "Would you like to continue with the version you have (y/n)? ",
                             sep = "\n"))
-      if (tolower(ans) != "y") exit_fun <- TRUE
+      if (tolower(ans) != "y")
+        exit_fun <- TRUE
     }
-    if (exit_fun) stop("Please download the historic data with\n",
-                       " the 'download_historic_data' function.")
   }
+
+  if (exit_fun) stop("Please download the historic data with\n",
+                     " the 'download_historic_data' function.")
 
   qry <- construct_historic_sql(emsid = emsid, parameter = parameter,
                                 param_code = param_code, from_date = from_date,

--- a/R/get_ems_data.R
+++ b/R/get_ems_data.R
@@ -96,18 +96,18 @@ get_ems_data <- function(which = "2yr", n = Inf, cols = "wq", force = FALSE, ask
     cols <- col_specs("names_only")
   }
 
+  if(check_only) return(TRUE)
+
   if (update) {
     if (ask) {
       stop_for_permission(paste0("rems would like to store a copy of the ", which,
                                  " ems data at", rems_data_dir(), ". Is that okay?"))
     }
     ret <- update_cache(which = which, n = n, cols = cols)
-    if(check_only) return(NULL)
-    return(add_rems_type(ret, which))
+  } else {
+    message("Fetching data from cache...")
+    ret <- ._remsCache_$get(which)[, cols]
   }
-  if(check_only) return(NULL)
-  message("Fetching data from cache...")
-  ret <- ._remsCache_$get(which)[, cols]
   add_rems_type(ret, which)
 }
 

--- a/R/get_ems_data.R
+++ b/R/get_ems_data.R
@@ -31,7 +31,8 @@
 #' Default \code{TRUE}
 #' @param dont_update should the function avoid updating the data even if there is a newer
 #' version available? Default \code{FALSE}
-#' @return a data frame
+#' @param dont_get should the function avoid retrieving the data from the cache? Default \code{FALSE}
+#' @return a data frame or NULL if dont_get = TRUE
 #' @details cols can specify any of the following column names as a character vector:
 #'
 #' \code{"EMS_ID", "MONITORING_LOCATION", "LATITUDE", "LONGITUDE", "LOCATION_TYPE",
@@ -66,7 +67,7 @@
 #' @import readr
 #' @import storr
 #' @import rappdirs
-get_ems_data <- function(which = "2yr", n = Inf, cols = "wq", force = FALSE, ask = TRUE, dont_update = FALSE) {
+get_ems_data <- function(which = "2yr", n = Inf, cols = "wq", force = FALSE, ask = TRUE, dont_update = FALSE, dont_get = FALSE) {
   which <- match.arg(which, c("2yr", "4yr"))
 
   update <- FALSE # Don't update by default
@@ -101,10 +102,12 @@ get_ems_data <- function(which = "2yr", n = Inf, cols = "wq", force = FALSE, ask
                                  " ems data at", rems_data_dir(), ". Is that okay?"))
     }
     ret <- update_cache(which = which, n = n, cols = cols)
-  } else {
-    message("Fetching data from cache...")
-    ret <- ._remsCache_$get(which)[, cols]
+    if(dont_get) return(NULL)
+    return(add_rems_type(ret, which))
   }
+  if(dont_get) return(NULL)
+  message("Fetching data from cache...")
+  ret <- ._remsCache_$get(which)[, cols]
   add_rems_type(ret, which)
 }
 

--- a/R/get_ems_data.R
+++ b/R/get_ems_data.R
@@ -31,8 +31,8 @@
 #' Default \code{TRUE}
 #' @param dont_update should the function avoid updating the data even if there is a newer
 #' version available? Default \code{FALSE}
-#' @param dont_get should the function avoid retrieving the data from the cache? Default \code{FALSE}
-#' @return a data frame or NULL if dont_get = TRUE
+#' @param check_only should the function retrieve the data from the cache or just check it's existence and currency? Default \code{FALSE}
+#' @return a data frame or NULL if check_only = TRUE
 #' @details cols can specify any of the following column names as a character vector:
 #'
 #' \code{"EMS_ID", "MONITORING_LOCATION", "LATITUDE", "LONGITUDE", "LOCATION_TYPE",
@@ -67,7 +67,7 @@
 #' @import readr
 #' @import storr
 #' @import rappdirs
-get_ems_data <- function(which = "2yr", n = Inf, cols = "wq", force = FALSE, ask = TRUE, dont_update = FALSE, dont_get = FALSE) {
+get_ems_data <- function(which = "2yr", n = Inf, cols = "wq", force = FALSE, ask = TRUE, dont_update = FALSE, check_only = FALSE) {
   which <- match.arg(which, c("2yr", "4yr"))
 
   update <- FALSE # Don't update by default
@@ -102,10 +102,10 @@ get_ems_data <- function(which = "2yr", n = Inf, cols = "wq", force = FALSE, ask
                                  " ems data at", rems_data_dir(), ". Is that okay?"))
     }
     ret <- update_cache(which = which, n = n, cols = cols)
-    if(dont_get) return(NULL)
+    if(check_only) return(NULL)
     return(add_rems_type(ret, which))
   }
-  if(dont_get) return(NULL)
+  if(check_only) return(NULL)
   message("Fetching data from cache...")
   ret <- ._remsCache_$get(which)[, cols]
   add_rems_type(ret, which)

--- a/man/get_ems_data.Rd
+++ b/man/get_ems_data.Rd
@@ -5,7 +5,7 @@
 \title{get EMS data from BC Data Catalogue}
 \usage{
 get_ems_data(which = "2yr", n = Inf, cols = "wq", force = FALSE,
-  ask = TRUE, dont_update = FALSE)
+  ask = TRUE, dont_update = FALSE, dont_get = FALSE)
 }
 \arguments{
 \item{which}{Defaults to \code{"2yr"} (past 2 years). You can also specify "4yr"
@@ -26,9 +26,11 @@ Default \code{TRUE}}
 
 \item{dont_update}{should the function avoid updating the data even if there is a newer
 version available? Default \code{FALSE}}
+
+\item{dont_get}{should the function avoid retrieving the data from the cache? Default \code{FALSE}}
 }
 \value{
-a data frame
+a data frame or NULL if dont_get = TRUE
 }
 \description{
 EMS data are distributed through the \href{https://catalogue.data.gov.bc.ca/dataset/bc-environmental-monitoring-system-results}{BC Data Catalogue}

--- a/man/get_ems_data.Rd
+++ b/man/get_ems_data.Rd
@@ -5,7 +5,7 @@
 \title{get EMS data from BC Data Catalogue}
 \usage{
 get_ems_data(which = "2yr", n = Inf, cols = "wq", force = FALSE,
-  ask = TRUE, dont_update = FALSE, dont_get = FALSE)
+  ask = TRUE, dont_update = FALSE, check_only = FALSE)
 }
 \arguments{
 \item{which}{Defaults to \code{"2yr"} (past 2 years). You can also specify "4yr"
@@ -27,10 +27,10 @@ Default \code{TRUE}}
 \item{dont_update}{should the function avoid updating the data even if there is a newer
 version available? Default \code{FALSE}}
 
-\item{dont_get}{should the function avoid retrieving the data from the cache? Default \code{FALSE}}
+\item{check_only}{should the function retrieve the data from the cache or just check it's existence and currency? Default \code{FALSE}}
 }
 \value{
-a data frame or NULL if dont_get = TRUE
+a data frame or NULL if check_only = TRUE
 }
 \description{
 EMS data are distributed through the \href{https://catalogue.data.gov.bc.ca/dataset/bc-environmental-monitoring-system-results}{BC Data Catalogue}

--- a/man/read_historic_data.Rd
+++ b/man/read_historic_data.Rd
@@ -5,7 +5,7 @@
 \title{Read historic ems data into R.}
 \usage{
 read_historic_data(emsid = NULL, parameter = NULL, param_code = NULL,
-  from_date = NULL, to_date = NULL, cols = "wq")
+  from_date = NULL, to_date = NULL, cols = "wq", ask = TRUE)
 }
 \arguments{
 \item{emsid}{A character vector of the ems id(s) of interest}
@@ -19,6 +19,8 @@ read_historic_data(emsid = NULL, parameter = NULL, param_code = NULL,
 \item{to_date}{A date string in a standard unambiguous format (e.g., "YYYY/MM/DD")}
 
 \item{cols}{colums. Default "wq". See \code{link{get_ems_data}} for further documentation.}
+
+\item{ask}{should the function check for cached data or updates? Default \code{TRUE}.}
 }
 \value{
 a data frame of the results

--- a/man/read_historic_data.Rd
+++ b/man/read_historic_data.Rd
@@ -5,7 +5,8 @@
 \title{Read historic ems data into R.}
 \usage{
 read_historic_data(emsid = NULL, parameter = NULL, param_code = NULL,
-  from_date = NULL, to_date = NULL, cols = "wq", ask = TRUE)
+  from_date = NULL, to_date = NULL, cols = "wq",
+  check_exists = TRUE)
 }
 \arguments{
 \item{emsid}{A character vector of the ems id(s) of interest}
@@ -20,7 +21,7 @@ read_historic_data(emsid = NULL, parameter = NULL, param_code = NULL,
 
 \item{cols}{colums. Default "wq". See \code{link{get_ems_data}} for further documentation.}
 
-\item{ask}{should the function check for cached data or updates? Default \code{TRUE}.}
+\item{check_exists}{should the function check for cached data or updates? Default \code{TRUE}.}
 }
 \value{
 a data frame of the results

--- a/man/read_historic_data.Rd
+++ b/man/read_historic_data.Rd
@@ -5,8 +5,7 @@
 \title{Read historic ems data into R.}
 \usage{
 read_historic_data(emsid = NULL, parameter = NULL, param_code = NULL,
-  from_date = NULL, to_date = NULL, cols = "wq",
-  check_exists = TRUE)
+  from_date = NULL, to_date = NULL, cols = "wq", check_db = TRUE)
 }
 \arguments{
 \item{emsid}{A character vector of the ems id(s) of interest}
@@ -21,7 +20,7 @@ read_historic_data(emsid = NULL, parameter = NULL, param_code = NULL,
 
 \item{cols}{colums. Default "wq". See \code{link{get_ems_data}} for further documentation.}
 
-\item{check_exists}{should the function check for cached data or updates? Default \code{TRUE}.}
+\item{check_db}{should the function check for cached data or updates? Default \code{TRUE}.}
 }
 \value{
 a data frame of the results


### PR DESCRIPTION
Apologies for multiple commits. Let me know if you'd like me to try again wth a different approach.

We'd like to modify two functions:
1. `get_ems_data()` 
add `dont_get` argument (default FALSE returns data.frame, TRUE returns NULL) to simply check whether data is cached or whether is update is available, but without returning the cached data. Default behaviour remains the same.

2. `filter_historic_data()`
add `check_exists` argument (default TRUE). setting `check_exists = FALSE` skips checking whether data exists/update available before filtering data. Default behaviour remains the same.

These modifications will be useful for the rems shiny app we are developing.