### PR TITLE
skip verification if ask = FALSE. #67

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: rems
 Title: Get Data from British Columbia's Environmental Monitoring
     System
-Version: 0.8.0
+Version: 0.8.0.9000
 Authors@R: 
     c(person(given = "Andy",
              family = "Teucher",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rems (development version)
 
+* `ask` parameter now skips all verification (caching and updates) when set to `FALSE` (#67, #68)
+
 # rems 0.8.0 
 
 * Switched from using SQLite to [DuckDB](https://duckdb.org/) as a backend for the historic database. This allows fast creation of the database directly from the csv file downloaded from the [B.C. Data Catalogue](https://catalogue.data.gov.bc.ca/dataset/949f2233-9612-4b06-92a9-903e817da659) (#52). 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# rems (development version)
+
 # rems 0.8.0 
 
 * Switched from using SQLite to [DuckDB](https://duckdb.org/) as a backend for the historic database. This allows fast creation of the database directly from the csv file downloaded from the [B.C. Data Catalogue](https://catalogue.data.gov.bc.ca/dataset/949f2233-9612-4b06-92a9-903e817da659) (#52). 

--- a/R/get_ems_data.R
+++ b/R/get_ems_data.R
@@ -27,7 +27,7 @@
 #' for water quality analysis, or a character vector of column names (see details below).
 #' @param force Default \code{FALSE}. Setting to \code{TRUE} will download new data even
 #' if it's not out of date on your computer.
-#' @param ask should the function ask for your permission to cache data on your computer?
+#' @param ask should the function ask for your permission to download and cache data on your computer?
 #' Default \code{TRUE}
 #' @param dont_update should the function checking for updates to the data and simply
 #' load the data from the cache? Default \code{FALSE}
@@ -101,9 +101,13 @@ get_ems_data <- function(which = "2yr", n = Inf, cols = "wq", force = FALSE,
 
     if (cache_date < unique(file_meta[["server_date"]])) {
     # nocov start
-      ans <- readline(paste0("Your version of ", which, " is dated ",
-        cache_date, " and there is a newer version available. Would you like to download it? (y/n)"))
-      if (tolower(ans) == "y") update <- TRUE
+      if (!ask) {
+        update <- TRUE
+      } else {
+        ans <- readline(paste0("Your version of ", which, " is dated ",
+                               cache_date, " and there is a newer version available. Would you like to download it? (y/n)"))
+        update <- tolower(ans) == "y"
+      }
     # nocov end
     }
   }

--- a/man/get_ems_data.Rd
+++ b/man/get_ems_data.Rd
@@ -28,7 +28,7 @@ for water quality analysis, or a character vector of column names (see details b
 \item{force}{Default \code{FALSE}. Setting to \code{TRUE} will download new data even
 if it's not out of date on your computer.}
 
-\item{ask}{should the function ask for your permission to cache data on your computer?
+\item{ask}{should the function ask for your permission to download and cache data on your computer?
 Default \code{TRUE}}
 
 \item{dont_update}{should the function checking for updates to the data and simply


### PR DESCRIPTION
`ask = FALSE` now skips verification for both caching and updating. Fixes #67﻿
